### PR TITLE
refactor#49(frontend): change color theme of connect me not game to m…

### DIFF
--- a/components/games/rj45/game-header.tsx
+++ b/components/games/rj45/game-header.tsx
@@ -22,12 +22,12 @@ export default function GameHeader({
   return (
     <div className="text-center space-y-3 max-w-md mx-auto">
       <div className="flex items-center justify-center gap-2">
-        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-cyan-700 tracking-tight">
+        <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-purple-700 tracking-tight">
           Connect Me Not: Ethernet Color Coding Game
         </h1>
         <button
           onClick={() => setShowInfo(!showInfo)}
-          className="text-cyan-600 hover:text-cyan-800 transition-colors"
+          className="text-purple-400 hover:text-purple-600 transition-colors"
           aria-label="Show information about RJ45 wiring"
         >
           <Info size={20} />
@@ -42,7 +42,7 @@ export default function GameHeader({
             exit={{ opacity: 0, height: 0 }}
             className="overflow-hidden"
           >
-            <div className="bg-white/80 backdrop-blur-sm p-3 rounded-lg shadow-sm text-sm text-slate-700">
+            <div className="bg-white/40 backdrop-blur-md border border-white/50 p-3 rounded-xl shadow-sm text-sm text-purple-900">
               <p>
                 RJ45 connectors use specific color patterns for network cables.
                 T568A and T568B are the two standard wiring patterns used in
@@ -54,8 +54,8 @@ export default function GameHeader({
       </AnimatePresence>
 
       {gameState === "select" && (
-        <div className="bg-white/70 backdrop-blur-sm p-4 rounded-lg shadow-sm">
-          <p className="text-slate-700 text-base sm:text-lg">
+        <div className="bg-white/40 backdrop-blur-md border border-white/50 p-4 rounded-xl shadow-sm">
+          <p className="text-purple-800 text-base sm:text-sm">
             Select a wiring standard to begin. You&apos;ll need to memorize the
             pattern, then arrange the wires correctly in 15 seconds.
           </p>
@@ -63,7 +63,7 @@ export default function GameHeader({
       )}
 
       {gameState === "learn" && (
-        <div className="flex items-center justify-center space-x-2 text-emerald-600 bg-emerald-50 p-3 rounded-lg shadow-sm">
+        <div className="flex items-center justify-center space-x-2 text-emerald-700 bg-emerald-50/80 backdrop-blur-sm border border-emerald-200 p-3 rounded-xl shadow-sm">
           <AlertCircle size={20} />
           <p className="font-medium text-base sm:text-lg">
             Memorize this pattern! Jumbling in 5 seconds...
@@ -72,7 +72,7 @@ export default function GameHeader({
       )}
 
       {gameState === "arrange" && (
-        <div className="flex items-center justify-center space-x-2 text-amber-600 bg-amber-50 p-3 rounded-lg shadow-sm">
+        <div className="flex items-center justify-center space-x-2 text-amber-700 bg-amber-50/80 backdrop-blur-sm border border-amber-200 p-3 rounded-xl shadow-sm">
           <Clock size={20} />
           <p className="font-medium text-base sm:text-lg">
             Arrange the wires correctly! Time left: {timeLeft}s
@@ -81,7 +81,7 @@ export default function GameHeader({
       )}
 
       {gameState === "success" && (
-        <div className="flex items-center justify-center space-x-2 text-emerald-600 bg-emerald-50 p-3 rounded-lg shadow-sm">
+        <div className="flex items-center justify-center space-x-2 text-emerald-700 bg-emerald-50/80 backdrop-blur-sm border border-emerald-200 p-3 rounded-xl shadow-sm">
           <Award size={20} />
           <p className="font-medium text-base sm:text-lg">
             Perfect wiring! You win!
@@ -90,7 +90,7 @@ export default function GameHeader({
       )}
 
       {gameState === "failure" && (
-        <div className="flex items-center justify-center space-x-2 text-red-600 bg-red-50 p-3 rounded-lg shadow-sm">
+        <div className="flex items-center justify-center space-x-2 text-rose-700 bg-rose-50/80 backdrop-blur-sm border border-rose-200 p-3 rounded-xl shadow-sm">
           <AlertCircle size={20} />
           <p className="font-medium text-base sm:text-lg">
             {timeExpired

--- a/components/games/rj45/rj45-game.tsx
+++ b/components/games/rj45/rj45-game.tsx
@@ -115,7 +115,7 @@ export default function RJ45Game({ gameId }: RJ45GameProps) {
         setGameState("failure");
         setShowCorrectPattern(true);
         toast("Time's up! Incorrect wire arrangement.", {
-          className: "bg-red-100 text-red-800 border-red-200",
+          className: "bg-rose-100 text-rose-800 border-rose-200",
         });
         submitScore({
           gameId,
@@ -155,7 +155,7 @@ export default function RJ45Game({ gameId }: RJ45GameProps) {
       setGameState("failure");
       setShowCorrectPattern(true); // Show the correct pattern
       toast("Incorrect wire arrangement! Check the correct pattern.", {
-        className: "bg-red-100 text-red-800 border-red-200",
+        className: "bg-rose-100 text-rose-800 border-rose-200",
       });
       submitScore({
         gameId,
@@ -192,7 +192,14 @@ export default function RJ45Game({ gameId }: RJ45GameProps) {
   return (
     <div
       ref={gameContainerRef}
-      className="flex flex-col items-center justify-center p-4 md:p-8 space-y-6 bg-gradient-to-br from-cyan-50 via-sky-50 to-blue-50 rounded-xl shadow-md relative"
+      className="flex flex-col items-center justify-center p-4 md:p-8 space-y-6 
+                relative overflow-hidden rounded-2xl shadow-2xl 
+                bg-purple-400/10 backdrop-blur-xl 
+                border border-white/30 
+                ring-1 ring-purple-200/20
+                after:pointer-events-none after:absolute after:inset-0 after:-z-10
+                after:content-[''] after:bg-gradient-to-br 
+                after:from-purple-300/20 after:via-transparent after:to-purple-800/20"
     >
       <GameHeader
         gameState={gameState}
@@ -228,19 +235,18 @@ export default function RJ45Game({ gameId }: RJ45GameProps) {
           onClick={() => setLeaderboardOpen(true)}
           variant="outline"
           size="lg"
-          className="bg-white border-cyan-200 hover:bg-cyan-50 hover:border-cyan-300 text-cyan-700 shadow-md"
+          className="bg-white/50 backdrop-blur-sm border-purple-300 hover:bg-purple-50/70 hover:border-purple-400 text-purple-600 shadow-sm rounded-xl"
         >
           Show Leaderboard
         </Button>
       )}
 
       <Dialog open={leaderboardOpen} onOpenChange={setLeaderboardOpen}>
-        <DialogContent className="sm:max-w-2xl">
+        <DialogContent className="sm:max-w-2xl border-purple-100">
           <DialogHeader>
-            <DialogTitle>Leaderboard</DialogTitle>
+            <DialogTitle className="text-purple-900">Leaderboard</DialogTitle>
             <DialogDescription>RJ45 scores and rankings</DialogDescription>
           </DialogHeader>
-
           <LeaderboardPanel
             gameId="rj45-game"
             limit={9999}
@@ -255,7 +261,8 @@ export default function RJ45Game({ gameId }: RJ45GameProps) {
           onClick={resetGame}
           variant="outline"
           size="lg"
-          className="bg-white border-cyan-200 hover:bg-cyan-50 hover:border-cyan-300 text-cyan-700 shadow-md flex items-center gap-2"
+          className="bg-white/50 backdrop-blur-sm border-purple-300 hover:bg-purple-50/70 hover:border-purple-400 text-purple-600 shadow-sm 
+                    flex items-center gap-2 rounded-xl"
         >
           <RotateCcw size={16} />
           Play Again

--- a/components/games/rj45/standard-selection.tsx
+++ b/components/games/rj45/standard-selection.tsx
@@ -16,16 +16,16 @@ export default function StandardSelection({
     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
       <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
         <Card
-          className="overflow-hidden border-2 border-cyan-200 hover:border-cyan-400 transition-all duration-200 cursor-pointer"
+          className="overflow-hidden border-2 border-purple-200 hover:border-purple-400 transition-all duration-200 cursor-pointer bg-white/40 backdrop-blur-md"
           onClick={() => selectStandard("T568A")}
         >
-          <div className="bg-gradient-to-r from-cyan-50 to-blue-50 p-4 sm:p-6">
+          <div className="bg-gradient-to-r from-purple-50/80 to-fuchsia-50/80 p-4 sm:p-6">
             <div className="text-center mb-4">
-              <span className="text-lg sm:text-xl font-bold text-cyan-700 bg-white px-3 py-1 rounded-full shadow-sm">
+              <span className="text-lg sm:text-xl font-bold text-purple-700 bg-white/80 px-3 py-1 rounded-full shadow-sm">
                 T568A
               </span>
             </div>
-            <div className="bg-white rounded-lg p-3 shadow-sm">
+            <div className="bg-white/80 rounded-lg p-3 shadow-sm">
               <div className="flex justify-center gap-1 sm:gap-2">
                 {WIRE_STANDARDS["T568A"].map((wire, i) => (
                   <div
@@ -59,16 +59,16 @@ export default function StandardSelection({
 
       <motion.div whileHover={{ scale: 1.02 }} whileTap={{ scale: 0.98 }}>
         <Card
-          className="overflow-hidden border-2 border-blue-200 hover:border-blue-400 transition-all duration-200 cursor-pointer"
+          className="overflow-hidden border-2 border-fuchsia-200 hover:border-fuchsia-400 transition-all duration-200 cursor-pointer bg-white/40 backdrop-blur-md"
           onClick={() => selectStandard("T568B")}
         >
-          <div className="bg-gradient-to-r from-blue-50 to-indigo-50 p-4 sm:p-6">
+          <div className="bg-gradient-to-r from-fuchsia-50/80 to-purple-50/80 p-4 sm:p-6">
             <div className="text-center mb-4">
-              <span className="text-lg sm:text-xl font-bold text-blue-700 bg-white px-3 py-1 rounded-full shadow-sm">
+              <span className="text-lg sm:text-xl font-bold text-fuchsia-700 bg-white/80 px-3 py-1 rounded-full shadow-sm">
                 T568B
               </span>
             </div>
-            <div className="bg-white rounded-lg p-3 shadow-sm">
+            <div className="bg-white/80 rounded-lg p-3 shadow-sm">
               <div className="flex justify-center gap-1 sm:gap-2">
                 {WIRE_STANDARDS["T568B"].map((wire, i) => (
                   <div

--- a/components/games/rj45/wire-arrangement.tsx
+++ b/components/games/rj45/wire-arrangement.tsx
@@ -21,8 +21,8 @@ export default function WireArrangement({
   isLargeScreen,
 }: WireArrangementProps) {
   return (
-    <Card className="p-4 bg-white shadow-md">
-      <h3 className="text-lg font-semibold text-center mb-4 text-cyan-700">
+    <Card className="p-4 bg-white/40 backdrop-blur-md border border-white/50 shadow-md rounded-2xl">
+      <h3 className="text-lg font-semibold text-center mb-4 text-purple-700">
         Arrange the wires in the correct order
       </h3>
 
@@ -36,7 +36,7 @@ export default function WireArrangement({
             isMobile
               ? "flex flex-col gap-2"
               : "flex flex-row gap-2 justify-center"
-          } p-4 bg-slate-50 rounded-lg min-h-[120px] w-full`}
+          } p-4 bg-white/30 backdrop-blur-sm rounded-xl min-h-[120px] w-full`}
         >
           {wires.map((wire, index) => (
             <Reorder.Item
@@ -47,13 +47,13 @@ export default function WireArrangement({
               <motion.div
                 className={`flex ${
                   isMobile ? "flex-row items-center" : "flex-col items-center"
-                } p-2 bg-white rounded-md hover:bg-slate-100 border border-slate-200 shadow-sm ${
+                } p-2 bg-white/80 rounded-xl hover:bg-white border border-purple-100 shadow-sm ${
                   isLargeScreen ? "w-[80px]" : ""
                 }`}
                 whileHover={{ scale: 1.02 }}
                 whileTap={{ scale: 0.98 }}
               >
-                <div className="text-center text-slate-500 font-medium mb-1 mx-2">
+                <div className="text-center text-purple-400 font-medium mb-1 mx-2">
                   {index + 1}
                 </div>
                 <div
@@ -71,11 +71,11 @@ export default function WireArrangement({
                     ></div>
                   )}
                 </div>
-                <div className="text-xs font-medium text-slate-700 bg-white px-2 py-1 rounded mx-2 my-1 shadow-sm whitespace-nowrap">
+                <div className="text-xs font-medium text-purple-700 bg-white/80 px-2 py-1 rounded mx-2 my-1 shadow-sm whitespace-nowrap">
                   {wire.name}
                 </div>
                 <div
-                  className={`text-slate-400 ${isMobile ? "ml-auto" : "mt-1"}`}
+                  className={`text-purple-300 ${isMobile ? "ml-auto" : "mt-1"}`}
                 >
                   {isMobile ? "⋮⋮" : "≡"}
                 </div>
@@ -88,7 +88,7 @@ export default function WireArrangement({
       <div className="mt-6 flex justify-center">
         <Button
           onClick={checkArrangement}
-          className="bg-cyan-600 hover:bg-cyan-700 text-white shadow-md text-base sm:text-lg px-4 sm:px-6 py-2"
+          className="bg-purple-500 hover:bg-purple-600 text-white shadow-md text-base sm:text-lg px-4 sm:px-6 py-2 rounded-xl"
         >
           Check Wiring
         </Button>

--- a/components/games/rj45/wire-pattern.tsx
+++ b/components/games/rj45/wire-pattern.tsx
@@ -9,9 +9,9 @@ type WirePatternProps = {
 
 export default function WirePattern({ standard, wires }: WirePatternProps) {
   return (
-    <Card className="p-4 bg-white shadow-md">
-      <h3 className="text-lg font-semibold text-center mb-4 text-cyan-700 flex items-center justify-center gap-2">
-        <span className="bg-cyan-100 text-cyan-700 px-2 py-1 rounded text-sm font-bold">
+    <Card className="p-4 bg-white/40 backdrop-blur-md border border-white/50 shadow-md rounded-2xl">
+      <h3 className="text-lg font-semibold text-center mb-4 text-purple-700 flex items-center justify-center gap-2">
+        <span className="bg-purple-100/80 text-purple-700 px-2 py-1 rounded text-sm font-bold">
           {standard}
         </span>
         Standard Pattern

--- a/components/home/game-selector-carousel.tsx
+++ b/components/home/game-selector-carousel.tsx
@@ -67,11 +67,11 @@ const games: GameOption[] = [
       "Master the art of RJ45 connector wiring standards. Learn T568A and T568B in this interactive challenge.",
     icon: <Cable size={100} />,
     color: {
-      from: "from-cyan-500",
-      to: "to-teal-600",
-      accent: "bg-cyan-500",
-      button: "bg-cyan-600",
-      buttonHover: "hover:bg-cyan-700",
+      from: "from-purple-500",
+      to: "to-fuchsia-600",
+      accent: "bg-purple-500",
+      button: "bg-purple-600",
+      buttonHover: "hover:bg-purple-700",
     },
   },
 ];


### PR DESCRIPTION
 
## ✨ What's New?
Applied a purple color scheme to align with the ICPEP theme for Connect me not game. The game's carousel was also updated to a purple color scheme. 

## 📷 Screenshots (IMPORTANT)
<img width="1614" height="706" alt="image" src="https://github.com/user-attachments/assets/e7664e3d-f8a6-4418-9c15-44d6c1a4e0a9" />
<img width="1919" height="1015" alt="image" src="https://github.com/user-attachments/assets/b32318e3-6769-46d2-8a3e-656f8df845a2" />

## 🔗 Related Issues

Closes #49 

## ✅ Checklist

- [x] Code follows project conventions.
- [x] Unused code, variables, and console logs have been removed.
- [x] Code compiles and runs without errors.
- [x] Build and tests succeeds locally.
- [x] Assigned at least one reviewer.
