### PR TITLE
feat: add leaderboard scoring system for overall and per-game

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,6 +15,7 @@ import GameHeader from "@/components/home/game-header";
 import HowToJoinSection from "@/components/home/how-to-join-section";
 import GameMechanicsSection from "@/components/home/game-mechanics-section";
 import GameSelectorCarousel from "@/components/home/game-selector-carousel";
+import OverallLeaderboardSection from "@/components/home/overall-leaderboard-section";
 import BackToHomeButton from "@/components/home/back-to-home-button";
 
 // Types
@@ -90,6 +91,7 @@ export default function GameHub() {
               <GameMechanicsSection />
             </div>
             <GameSelectorCarousel navigateTo={navigateTo} />
+            <OverallLeaderboardSection />
           </div>
         );
     }

--- a/components/games/leaderboard/overall-leaderboard-panel.tsx
+++ b/components/games/leaderboard/overall-leaderboard-panel.tsx
@@ -4,33 +4,22 @@ import { useEffect, useMemo, useState } from "react";
 import { Card } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 import { useLeaderboard } from "@/contexts/leaderboard-context";
+import { buildOverallLeaderboard } from "@/lib/leaderboard-utils/overall-leaderboard";
 import TopThreePodium from "@/components/games/leaderboard/top-three-podium";
 
-type LeaderboardPanelProps = {
-  gameId: string;
+type OverallLeaderboardPanelProps = {
   limit?: number;
   className?: string;
   leaderboardKey?: number;
   entriesClassName?: string;
 };
 
-export default function LeaderboardPanel({
-  gameId,
-  limit = 5,
+export default function OverallLeaderboardPanel({
+  limit = 20,
   className,
   leaderboardKey = 0,
   entriesClassName,
-}: LeaderboardPanelProps) {
-  const theme = useMemo(
-    () => ({
-      card: "bg-white/60 backdrop-blur-sm border border-pink-200 shadow-[0_8px_30px_rgba(236,72,153,0.15)] rounded-2xl",
-      title:
-        "bg-clip-text text-transparent bg-gradient-to-r from-pink-600 to-fuchsia-500 font-black tracking-tight",
-      metric: "text-fuchsia-600 font-bold uppercase tracking-wider text-xs",
-    }),
-    [],
-  );
-
+}: OverallLeaderboardPanelProps) {
   const { leaderboardData, updateLeaderboardData } = useLeaderboard();
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
@@ -53,67 +42,61 @@ export default function LeaderboardPanel({
     void load();
 
     return () => controller.abort();
-  }, [gameId, leaderboardKey]);
+  }, [leaderboardKey]);
 
-  const game = leaderboardData?.games?.[gameId] ?? null;
-
-  const entries = useMemo(() => {
-    if (!game?.entries) return [];
-
-    const sorted = [...game.entries].sort((a, b) => {
-      const delta = a.score - b.score;
-      return game.order === "asc" ? delta : -delta;
-    });
-
-    return sorted.slice(0, Math.max(0, limit));
-  }, [game?.entries, game?.order, limit]);
+  const entries = useMemo(
+    () => buildOverallLeaderboard(leaderboardData, limit),
+    [leaderboardData, limit],
+  );
 
   const remainingEntries = useMemo(() => entries.slice(3), [entries]);
 
   return (
     <Card
-      className={cn("w-full max-w-2xl backdrop-blur-sm", theme.card, className)}
+      className={cn(
+        "w-full max-w-2xl bg-white/60 backdrop-blur-sm border border-pink-200 shadow-[0_8px_30px_rgba(236,72,153,0.15)] rounded-2xl",
+        className,
+      )}
     >
       <div className="p-5 sm:p-6 space-y-3">
         <div className="flex items-center justify-between">
-          <h2 className={cn("text-lg sm:text-xl font-semibold", theme.title)}>
+          <h2 className="text-lg sm:text-xl bg-clip-text text-transparent bg-gradient-to-r from-pink-600 to-fuchsia-500 font-black tracking-tight">
             Leaderboard
           </h2>
-          {game?.metric && (
-            <span className={cn("text-sm", theme.metric)}>{game.metric}</span>
-          )}
+          <span className="text-fuchsia-600 font-bold uppercase tracking-wider text-xs">
+            TOTAL SCORE
+          </span>
         </div>
 
         {loading && <p className="text-sm text-slate-600">Loading leaderboard...</p>}
 
         {!loading && error && <p className="text-sm text-rose-700">{error}</p>}
 
-        {!loading && !error && !game && (
-          <p className="text-sm text-slate-600">
-            No leaderboard data found for this game.
-          </p>
-        )}
-
-        {!loading && !error && game && entries.length === 0 && (
+        {!loading && !error && entries.length === 0 && (
           <p className="text-sm text-slate-600">No entries yet.</p>
         )}
 
-        {!loading && !error && game && entries.length > 0 && (
+        {!loading && !error && entries.length > 0 && (
           <>
-            <TopThreePodium entries={entries.map((entry) => ({ name: entry.name, score: entry.score }))} />
+            <TopThreePodium
+              entries={entries.map((entry) => ({
+                name: entry.name,
+                score: entry.totalScore,
+              }))}
+            />
 
             {remainingEntries.length > 0 && (
               <ol className={cn("space-y-2", entriesClassName)}>
                 {remainingEntries.map((entry, index) => (
                   <li
-                    key={`${entry.name}-${entry.createdAt}-${index}`}
+                    key={`${entry.name}-${entry.latestActivityAt}-${index}`}
                     className="flex items-center justify-between text-base text-slate-700"
                   >
                     <span className="font-medium">
                       {index + 4}. {entry.name}
                     </span>
                     <span className="tabular-nums text-slate-800">
-                      {entry.score}
+                      {entry.totalScore}
                     </span>
                   </li>
                 ))}

--- a/components/games/leaderboard/top-three-podium.tsx
+++ b/components/games/leaderboard/top-three-podium.tsx
@@ -1,0 +1,70 @@
+import { cn } from "@/lib/utils";
+
+type PodiumEntry = {
+  name: string;
+  score: number;
+};
+
+type TopThreePodiumProps = {
+  entries: PodiumEntry[];
+  className?: string;
+};
+
+function getInitials(name: string) {
+  const words = name.trim().split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "?";
+  if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+  return `${words[0][0]}${words[1][0]}`.toUpperCase();
+}
+
+export default function TopThreePodium({ entries, className }: TopThreePodiumProps) {
+  const topThree = entries.slice(0, 3);
+  const slots = [
+    { entry: topThree[1], place: 2, blockHeight: "h-20 sm:h-24", tone: "from-slate-200 to-slate-300" },
+    { entry: topThree[0], place: 1, blockHeight: "h-28 sm:h-32", tone: "from-amber-200 to-yellow-300" },
+    { entry: topThree[2], place: 3, blockHeight: "h-16 sm:h-20", tone: "from-orange-200 to-rose-300" },
+  ];
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-pink-100 bg-gradient-to-b from-white to-pink-50/60 p-3 sm:p-4",
+        className,
+      )}
+    >
+      <div className="mx-auto flex max-w-xl items-end justify-center gap-2 sm:gap-4">
+        {slots.map((slot) => (
+          <div key={`podium-${slot.place}`} className="w-24 sm:w-28">
+            <div className="mb-2 min-h-16 text-center">
+              {slot.entry ? (
+                <>
+                  <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full border-2 border-white bg-gradient-to-br from-fuchsia-500 to-pink-500 text-xs font-bold text-white shadow">
+                    {getInitials(slot.entry.name)}
+                  </div>
+                  <p className="mt-1 truncate px-1 text-xs sm:text-sm font-semibold text-slate-800">
+                    {slot.entry.name}
+                  </p>
+                  <p className="text-xs font-medium text-fuchsia-700">{slot.entry.score}</p>
+                </>
+              ) : (
+                <p className="text-xs text-slate-400">No player</p>
+              )}
+            </div>
+
+            <div
+              className={cn(
+                "relative overflow-hidden rounded-t-lg border border-white/70 bg-gradient-to-b shadow-inner",
+                slot.blockHeight,
+                slot.tone,
+              )}
+            >
+              <span className="absolute inset-x-0 top-2 text-center text-3xl font-black text-slate-700/80">
+                {slot.place}
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/home/game-selector-carousel.tsx
+++ b/components/home/game-selector-carousel.tsx
@@ -10,8 +10,17 @@ import {
   ChevronLeft,
   ChevronRight,
   Play,
+  Trophy,
 } from "lucide-react";
 import type { GameType } from "@/lib/types";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import LeaderboardPanel from "@/components/games/leaderboard/leaderboard-panel";
 
 type GameCardsProps = {
   navigateTo: (game: GameType) => void;
@@ -78,6 +87,7 @@ const games: GameOption[] = [
 
 export default function GameSelectorCarousel({ navigateTo }: GameCardsProps) {
   const [current, setCurrent] = useState(0);
+  const [isLeaderboardOpen, setIsLeaderboardOpen] = useState(false);
 
   const paginate = useCallback((newDirection: number) => {
     setCurrent((prev) => (prev + newDirection + games.length) % games.length);
@@ -136,13 +146,23 @@ export default function GameSelectorCarousel({ navigateTo }: GameCardsProps) {
                   {game.title}
                 </h2>
 
-                <Button
-                  onClick={() => navigateTo(game.id)}
-                  className={`${game.color.button} ${game.color.buttonHover} text-white font-bold px-6 py-3 shadow-lg flex items-center gap-2`}
-                >
-                  <Play size={20} fill="white" />
-                  Play Now
-                </Button>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button
+                    onClick={() => navigateTo(game.id)}
+                    className={`${game.color.button} ${game.color.buttonHover} text-white font-bold px-6 py-3 shadow-lg flex items-center gap-2`}
+                  >
+                    <Play size={20} fill="white" />
+                    Play Now
+                  </Button>
+                  <Button
+                    onClick={() => setIsLeaderboardOpen(true)}
+                    variant="outline"
+                    className="bg-white/85 border-white/90 text-slate-900 hover:bg-white font-semibold inline-flex items-center gap-2"
+                  >
+                    <Trophy size={16} />
+                    Leaderboard
+                  </Button>
+                </div>
               </motion.div>
             </div>
           </motion.div>
@@ -246,6 +266,18 @@ export default function GameSelectorCarousel({ navigateTo }: GameCardsProps) {
           <ChevronRight size={24} />
         </motion.button>
       </div>
+
+      <Dialog open={isLeaderboardOpen} onOpenChange={setIsLeaderboardOpen}>
+        <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>{game.title} Leaderboard</DialogTitle>
+            <DialogDescription>
+              Top players for this game.
+            </DialogDescription>
+          </DialogHeader>
+          <LeaderboardPanel gameId={game.id} limit={50} className="w-full max-w-none" />
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/components/home/overall-leaderboard-section.tsx
+++ b/components/home/overall-leaderboard-section.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Trophy, Medal, Crown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { useLeaderboard } from "@/contexts/leaderboard-context";
+import { buildOverallLeaderboard } from "@/lib/leaderboard-utils/overall-leaderboard";
+import OverallLeaderboardPanel from "@/components/games/leaderboard/overall-leaderboard-panel";
+
+function rankAccent(rank: number) {
+  if (rank === 1) return "from-amber-300 via-yellow-200 to-amber-400 border-amber-300";
+  if (rank === 2) return "from-slate-200 via-slate-100 to-slate-300 border-slate-300";
+  if (rank === 3) return "from-orange-200 via-rose-100 to-orange-300 border-orange-300";
+  return "from-white to-white border-slate-200";
+}
+
+export default function OverallLeaderboardSection() {
+  const { leaderboardData, updateLeaderboardData } = useLeaderboard();
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+
+      const result = await updateLeaderboardData();
+      if (result.error) setError(result.error);
+
+      setLoading(false);
+    };
+
+    void load();
+  }, []);
+
+  const top5 = useMemo(
+    () => buildOverallLeaderboard(leaderboardData, 5),
+    [leaderboardData],
+  );
+
+  return (
+    <section className="mt-8 md:mt-10">
+      <div className="relative overflow-hidden rounded-2xl border border-slate-200 bg-gradient-to-br from-amber-50 via-white to-rose-50 p-5 md:p-8 shadow-lg">
+        <div className="absolute -top-16 -right-16 h-40 w-40 rounded-full bg-amber-200/40 blur-2xl" />
+        <div className="absolute -bottom-16 -left-16 h-40 w-40 rounded-full bg-rose-200/40 blur-2xl" />
+
+        <div className="relative">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.2em] text-amber-700">
+                Hall of Fame
+              </p>
+              <h3 className="mt-1 text-2xl md:text-3xl font-black text-slate-900">
+                Overall Leaderboard
+              </h3>
+              <p className="mt-2 text-sm text-slate-600">
+                Top 5 based on combined scores from all games.
+              </p>
+            </div>
+
+            <Button
+              onClick={() => setIsDialogOpen(true)}
+              className="bg-slate-900 hover:bg-slate-800 text-white font-semibold inline-flex items-center gap-2"
+            >
+              <Trophy size={18} />
+              View Full Leaderboard
+            </Button>
+          </div>
+
+          <div className="mt-5 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-3">
+            {loading && (
+              <p className="col-span-full text-sm text-slate-600">Loading overall rankings...</p>
+            )}
+
+            {!loading && error && (
+              <p className="col-span-full text-sm text-rose-700">{error}</p>
+            )}
+
+            {!loading && !error && top5.length === 0 && (
+              <p className="col-span-full text-sm text-slate-600">No entries yet.</p>
+            )}
+
+            {!loading &&
+              !error &&
+              top5.map((entry, index) => {
+                const rank = index + 1;
+                return (
+                  <div
+                    key={`${entry.name}-${entry.latestActivityAt}-${rank}`}
+                    className={`rounded-xl border bg-gradient-to-br ${rankAccent(rank)} p-4 shadow-sm`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-bold text-slate-800">#{rank}</p>
+                      {rank === 1 && <Crown size={16} className="text-amber-700" />}
+                      {rank > 1 && rank <= 3 && <Medal size={16} className="text-slate-600" />}
+                    </div>
+                    <p className="mt-2 truncate text-base font-bold text-slate-900">
+                      {entry.name}
+                    </p>
+                    <p className="mt-1 text-sm text-slate-700">Score: {entry.totalScore}</p>
+                    <p className="text-xs text-slate-500">Games: {entry.gamesPlayed}</p>
+                  </div>
+                );
+              })}
+          </div>
+        </div>
+      </div>
+
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogContent className="sm:max-w-2xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Overall Leaderboard</DialogTitle>
+            <DialogDescription>
+              Combined standings from LED Memory, Tech Tac Toe, and RJ45.
+            </DialogDescription>
+          </DialogHeader>
+
+          <OverallLeaderboardPanel limit={50} className="w-full max-w-none" />
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/lib/leaderboard-utils/overall-leaderboard.ts
+++ b/lib/leaderboard-utils/overall-leaderboard.ts
@@ -1,0 +1,53 @@
+import { LeaderboardDataType } from "@/lib/types";
+
+export type OverallLeaderboardEntry = {
+  name: string;
+  totalScore: number;
+  gamesPlayed: number;
+  latestActivityAt: string;
+};
+
+export function buildOverallLeaderboard(
+  leaderboardData: LeaderboardDataType | null | undefined,
+  limit = 20,
+): OverallLeaderboardEntry[] {
+  if (!leaderboardData?.games) return [];
+
+  const totals = new Map<string, OverallLeaderboardEntry>();
+
+  Object.values(leaderboardData.games).forEach((game) => {
+    game.entries.forEach((entry) => {
+      const normalizedName = entry.name.trim().toUpperCase();
+      const numericScore = Number(entry.score);
+
+      if (!normalizedName || Number.isNaN(numericScore)) return;
+
+      const activityAt = entry.updatedAt ?? entry.createdAt;
+      const existing = totals.get(normalizedName);
+
+      if (!existing) {
+        totals.set(normalizedName, {
+          name: normalizedName,
+          totalScore: numericScore,
+          gamesPlayed: 1,
+          latestActivityAt: activityAt,
+        });
+        return;
+      }
+
+      existing.totalScore += numericScore;
+      existing.gamesPlayed += 1;
+
+      if (new Date(activityAt).getTime() > new Date(existing.latestActivityAt).getTime()) {
+        existing.latestActivityAt = activityAt;
+      }
+    });
+  });
+
+  return [...totals.values()]
+    .sort((a, b) => {
+      if (b.totalScore !== a.totalScore) return b.totalScore - a.totalScore;
+      return new Date(b.latestActivityAt).getTime() - new Date(a.latestActivityAt).getTime();
+    })
+    .slice(0, Math.max(0, limit));
+}

--- a/public/leaderboard.json
+++ b/public/leaderboard.json
@@ -24,6 +24,12 @@
           "updatedAt": "2026-03-28T14:53:52.878Z"
         },
         {
+          "name": "ASDSADASD",
+          "score": 7,
+          "createdAt": "2026-03-29T08:13:16.602Z",
+          "updatedAt": "2026-03-29T08:32:40.252Z"
+        },
+        {
           "name": "SS",
           "score": 6,
           "createdAt": "2026-03-26T03:17:22.564Z",
@@ -161,6 +167,12 @@
           "updatedAt": "2026-03-28T14:56:32.780Z"
         },
         {
+          "name": "ASDSADASD",
+          "score": 2,
+          "createdAt": "2026-03-29T08:31:43.256Z",
+          "updatedAt": "2026-03-29T08:33:33.542Z"
+        },
+        {
           "name": "SLADKJF",
           "score": 0,
           "createdAt": "2026-03-26T03:53:32.577Z"
@@ -252,6 +264,11 @@
           "name": "AI MEDIUM",
           "score": 1.5,
           "createdAt": "2026-03-26T07:15:27.377Z"
+        },
+        {
+          "name": "ASDSADASD",
+          "score": 1.5,
+          "createdAt": "2026-03-29T08:15:54.999Z"
         },
         {
           "name": "JOE",

--- a/public/players.json
+++ b/public/players.json
@@ -112,5 +112,11 @@
     "color": "blue",
     "createdAt": "2026-03-28T15:02:59.659Z",
     "updatedAt": null
+  },
+  {
+    "name": "asdsadasd",
+    "color": "blue",
+    "createdAt": "2026-03-29T08:12:55.520Z",
+    "updatedAt": null
   }
 ]


### PR DESCRIPTION
## ✨ What's New?
Added an overall leaderboard on the home page that combines player scores from all games and shows the top players. Added dialog-based leaderboard views so users can open game-specific leaderboards directly from each game card in the carousel, while still keeping the overall leaderboard view. Updated the leaderboard UI to be cleaner and consistent by adding a Top 3 podium display and listing the remaining ranks below it.

## 📷 Screenshots (IMPORTANT)
<img width="1069" height="828" alt="image" src="https://github.com/user-attachments/assets/44272a4c-c2eb-4b5d-85e9-c52ba4d34aa3" />
<img width="672" height="770" alt="image" src="https://github.com/user-attachments/assets/90ca5441-2fe7-4db5-8c50-9d6dfbc42225" />
<img width="672" height="770" alt="image" src="https://github.com/user-attachments/assets/de3c54e4-7994-4be7-a32a-7fc8b0a9a5e9" />

## 🔗 Related Issues

Closes #51 

## ✅ Checklist

- [ ] Code follows project conventions.
- [ ] Unused code, variables, and console logs have been removed.
- [ ] Code compiles and runs without errors.
- [ ] Build and tests succeeds locally.
- [ ] Assigned at least one reviewer.