### PR TITLE
fix/#76(game-logic): remove modal blocking and start game when diffic…

### DIFF
--- a/components/home/edit-players/edit-player/create-player-dialog.tsx
+++ b/components/home/edit-players/edit-player/create-player-dialog.tsx
@@ -22,7 +22,7 @@ type CreatePlayerDialogProps = {
   setIsOpen: (open: boolean) => void;
   currPlayer: BoothPlayerType | null;
   setCurrPlayer: (player: BoothPlayerType | null) => void;
-  onExit: () => void;
+  onExit: (value: boolean) => void;
 };
 export const CreatePlayerDialog = ({
   team,
@@ -47,7 +47,7 @@ export const CreatePlayerDialog = ({
     if (!open) {
       // If the user clicks the X, presses Escape, or clicks the backdrop to close it
       if (onExit) {
-        onExit();
+        onExit(true);
       } else {
         setIsOpen(false);
       }
@@ -91,6 +91,7 @@ export const CreatePlayerDialog = ({
     setPlayerName("");
     setSelectedColor(defaultColor);
     handleOpenChange(false);
+    onExit(false);
     toast.custom(() => (
       <NotificationToaster
         variant="success"

--- a/components/home/edit-players/edit-player/select-player-dialog.tsx
+++ b/components/home/edit-players/edit-player/select-player-dialog.tsx
@@ -20,7 +20,7 @@ type SelectPlayerDialogProps = {
   setIsOpen: (open: boolean) => void;
   currPlayer: BoothPlayerType | null;
   setCurrPlayer: (player: BoothPlayerType | null) => void;
-  onExit: () => void;
+  onExit: (value: boolean) => void;
 };
 export const SelectPlayerDialog = ({
   team,
@@ -45,7 +45,7 @@ export const SelectPlayerDialog = ({
     if (!open) {
       // If the user clicks the X, presses Escape, or clicks the backdrop to close it
       if (onExit) {
-        onExit();
+        onExit(true);
       } else {
         setIsOpen(false);
       }
@@ -73,6 +73,7 @@ export const SelectPlayerDialog = ({
     setPlayerName("");
     setSelectedColor(defaultColor);
     handleOpenChange(false);
+    onExit(false);
     toast.custom(() => (
       <NotificationToaster
         variant="success"

--- a/components/home/edit-players/edit-players.tsx
+++ b/components/home/edit-players/edit-players.tsx
@@ -38,10 +38,14 @@ export const EditPlayers = ({
   }, [isEditTeamDialogOpen]);
 
   // open edit team dialog when both create and select player dialogs are exited
-  const onExitCreateOrSelectPlayerDialog = () => {
+  const onExitCreateOrSelectPlayerDialog = (value: boolean) => {
     setIsCreatePlayerDialogOpen(false);
     setIsSelectPlayerDialogOpen(false);
-    setIsEditTeamDialogOpen(true);
+    if (value) {
+      setIsEditTeamDialogOpen(true);
+    } else {
+      setIsEditTeamDialogOpen(false);
+    }
   };
 
   const handleEditTeamNext = (


### PR DESCRIPTION
…ulty is selected

## ✨ What's New?
- Refactored onExitCreateOrSelectPlayerDialog on edit-players.tsx to use a boolean check. This ensures the EditTeam dialog only opens on a successful submission and stays closed if the user cancels, preventing UI overlap and blocking.

## 📷 Screenshots (IMPORTANT)

## 🔗 Related Issues

Closes #76 

## ✅ Checklist

- [ ] Code follows project conventions.
- [ ] Unused code, variables, and console logs have been removed.
- [ ] Code compiles and runs without errors.
- [ ] Build and tests succeeds locally.
- [ ] Assigned at least one reviewer.
